### PR TITLE
fix: skip processing for invalid input PURLs in scanner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ export const scanner: Bun.Security.Scanner = {
 
               const match = artifact.inputPurl.match(purlRegex);
 
+              if (!match) continue;
+
               const name = match[1];
               const version = match[2];
 


### PR DESCRIPTION
Added a `match` guard to safely skip artifacts that don’t match the expected PURL format, preventing runtime errors.