### PR TITLE
refactor+test: extract advisory mapping into a pure, unit-tested module

### DIFF
--- a/src/advisories.ts
+++ b/src/advisories.ts
@@ -1,0 +1,98 @@
+import type Bun from 'bun'
+import { PackageURL } from '@socketregistry/packageurl-js'
+import type { SocketArtifact } from './types'
+
+/**
+ * Map Socket artifacts to Bun security advisories. Pure — no I/O — so the
+ * alert→advisory mapping (level, description assembly, overview URL) is unit
+ * testable without the module-init token bootstrap that `index.ts` runs.
+ *
+ * Behavior contract (kept identical to the original inline `scan()` loop):
+ * - An artifact with no alerts contributes nothing.
+ * - An artifact whose `inputPurl` cannot be parsed is skipped entirely — its
+ * socket.dev overview URL can't be built, and every alert on it shares that
+ * same unparseable purl.
+ * - `action: 'error'` maps to `level: 'fatal'`; anything else maps to `'warn'`
+ * (Bun only recognizes `'fatal' | 'warn'`).
+ * - The description is assembled from the typo-squat hint, the alert
+ * description, the note, and the fix, joined by blank lines with a trailing
+ * newline.
+ */
+export function artifactsToAdvisories(
+  artifacts: SocketArtifact[],
+): Bun.Security.Advisory[] {
+  const advisories: Bun.Security.Advisory[] = []
+
+  for (let i = 0, { length } = artifacts; i < length; i += 1) {
+    const artifact = artifacts[i]!
+
+    if (!artifact.alerts || artifact.alerts.length === 0) {
+      continue
+    }
+
+    const parsed = parseNpmPurl(artifact.inputPurl)
+
+    if (!parsed) {
+      continue
+    }
+
+    const { name, version } = parsed
+    const url = `https://socket.dev/npm/package/${name}/overview/${version}`
+    const { alerts } = artifact
+
+    for (let j = 0, alertCount = alerts.length; j < alertCount; j += 1) {
+      const alert = alerts[j]!
+      const description = ['']
+
+      if (alert.type === 'didYouMean' && alert.props.alternatePackage) {
+        description.push(
+          `This package could be a typo-squatting attempt of another package (${alert.props.alternatePackage}).`,
+        )
+      }
+
+      if (alert.props.description) {
+        description.push(alert.props.description)
+      }
+
+      if (alert.props.note) {
+        description.push(alert.props.note)
+      }
+
+      const fix = alert.fix?.description
+
+      if (fix) {
+        description.push(`Fix: ${fix}`)
+      }
+
+      advisories.push({
+        level: alert.action === 'error' ? 'fatal' : 'warn',
+        package: artifact.inputPurl,
+        url,
+        description: description.join('\n\n') + '\n',
+      })
+    }
+  }
+
+  return advisories
+}
+
+/**
+ * Parse an npm purl into the `@scope/name` + version pair the socket.dev
+ * overview URL wants. `PackageURL.fromString` decodes percent-encoded scopes
+ * the API can legally emit in `inputPurl` (the old hand-rolled regex never
+ * did); it throws on malformed purls, so map that to `undefined` to preserve
+ * the skip-on-no-match behavior.
+ */
+export function parseNpmPurl(
+  purl: string,
+): { name: string; version: string } | undefined {
+  try {
+    const { name, namespace, version } = PackageURL.fromString(purl)
+    if (!name || !version) {
+      return undefined
+    }
+    return { name: namespace ? `${namespace}/${name}` : name, version }
+  } catch {
+    return undefined
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,18 @@
 import Bun from 'bun'
 import path from 'node:path'
 import os from 'node:os'
-import { PackageURL } from '@socketregistry/packageurl-js'
+import { artifactsToAdvisories, parseNpmPurl } from './advisories'
 import { authenticated } from './modes/authenticated'
 import { unauthenticated } from './modes/unauthenticated'
 import { getDefaultLogger } from '@socketsecurity/lib/logger/default'
 import { readSocketApiTokenSync } from '@socketsecurity/lib/secrets/socket-api-token'
 import { getXdgDataHome } from '@socketsecurity/lib/env/xdg'
+
+// Re-exported for backwards compatibility: `parseNpmPurl` used to live here.
+// The alert→advisory mapping and purl parsing now live in the side-effect-free
+// `./advisories` module so they're unit testable without this file's
+// module-init token bootstrap.
+export { parseNpmPurl }
 
 const logger = getDefaultLogger()
 
@@ -70,27 +76,6 @@ const scannerImplementation = socketApiToken
   ? authenticated(socketApiToken)
   : unauthenticated()
 
-/**
- * Parse an npm purl into the `@scope/name` + version pair the socket.dev
- * overview URL wants. `PackageURL.fromString` decodes percent-encoded scopes
- * the API can legally emit in `inputPurl` (the old hand-rolled regex never
- * did); it throws on malformed purls, so map that to `undefined` to preserve
- * the skip-on-no-match behavior.
- */
-export function parseNpmPurl(
-  purl: string,
-): { name: string; version: string } | undefined {
-  try {
-    const { name, namespace, version } = PackageURL.fromString(purl)
-    if (!name || !version) {
-      return undefined
-    }
-    return { name: namespace ? `${namespace}/${name}` : name, version }
-  } catch {
-    return undefined
-  }
-}
-
 export const scanner: Bun.Security.Scanner = {
   async scan({ packages }: { packages: Bun.Security.Package[] }) {
     const results: Bun.Security.Advisory[] = []
@@ -99,50 +84,7 @@ export const scanner: Bun.Security.Scanner = {
       const scanResults = scannerImplementation(packages)
 
       for await (const artifacts of scanResults) {
-        for (const artifact of artifacts) {
-          if (artifact.alerts && artifact.alerts.length > 0) {
-            for (const alert of artifact.alerts) {
-              const description = ['']
-
-              if (alert.type === 'didYouMean' && alert.props.alternatePackage) {
-                description.push(
-                  `This package could be a typo-squatting attempt of another package (${alert.props.alternatePackage}).`,
-                )
-              }
-
-              if (alert.props.description) {
-                description.push(alert.props.description)
-              }
-
-              if (alert.props.note) {
-                description.push(alert.props.note)
-              }
-
-              const fix = alert.fix?.description
-
-              if (fix) {
-                description.push(`Fix: ${fix}`)
-              }
-
-              const parsed = parseNpmPurl(artifact.inputPurl)
-
-              if (!parsed) {
-                continue
-              }
-
-              const { name, version } = parsed
-
-              const url = `https://socket.dev/npm/package/${name}/overview/${version}`
-
-              results.push({
-                level: alert.action === 'error' ? 'fatal' : 'warn',
-                package: artifact.inputPurl,
-                url,
-                description: description.join('\n\n') + '\n',
-              })
-            }
-          }
-        }
+        results.push(...artifactsToAdvisories(artifacts))
       }
     }
     return results

--- a/test/advisories.test.ts
+++ b/test/advisories.test.ts
@@ -36,11 +36,7 @@ describe('parseNpmPurl', () => {
 })
 
 describe('artifactsToAdvisories', () => {
-  function artifact(
-    overrides: Partial<SocketArtifact> & {
-      alerts?: SocketArtifact['alerts']
-    } = {},
-  ): SocketArtifact {
+  function artifact(overrides: Partial<SocketArtifact> = {}): SocketArtifact {
     return {
       inputPurl: 'pkg:npm/lodash@4.17.21',
       alerts: [],

--- a/test/advisories.test.ts
+++ b/test/advisories.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'bun:test'
+import { artifactsToAdvisories, parseNpmPurl } from '../src/advisories'
+import type { SocketArtifact } from '../src/types'
+
+describe('parseNpmPurl', () => {
+  test('parses an unscoped npm purl', () => {
+    expect(parseNpmPurl('pkg:npm/lodash@4.17.21')).toEqual({
+      name: 'lodash',
+      version: '4.17.21',
+    })
+  })
+
+  test('parses a scoped npm purl, rejoining namespace and name', () => {
+    expect(parseNpmPurl('pkg:npm/%40scope/pkg@1.2.3')).toEqual({
+      name: '@scope/pkg',
+      version: '1.2.3',
+    })
+  })
+
+  test('decodes a percent-encoded scope the API can emit', () => {
+    // `%40angular` is the percent-encoded form of `@angular`.
+    expect(parseNpmPurl('pkg:npm/%40angular/core@17.0.0')).toEqual({
+      name: '@angular/core',
+      version: '17.0.0',
+    })
+  })
+
+  test('returns undefined when the version is missing', () => {
+    expect(parseNpmPurl('pkg:npm/lodash')).toBeUndefined()
+  })
+
+  test('returns undefined for a malformed purl', () => {
+    expect(parseNpmPurl('not-a-purl')).toBeUndefined()
+    expect(parseNpmPurl('')).toBeUndefined()
+  })
+})
+
+describe('artifactsToAdvisories', () => {
+  function artifact(
+    overrides: Partial<SocketArtifact> & {
+      alerts?: SocketArtifact['alerts']
+    } = {},
+  ): SocketArtifact {
+    return {
+      inputPurl: 'pkg:npm/lodash@4.17.21',
+      alerts: [],
+      ...overrides,
+    }
+  }
+
+  test('returns an empty list for no artifacts', () => {
+    expect(artifactsToAdvisories([])).toEqual([])
+  })
+
+  test('skips an artifact with no alerts', () => {
+    expect(artifactsToAdvisories([artifact({ alerts: [] })])).toEqual([])
+  })
+
+  test('maps an error alert to a fatal advisory', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        alerts: [{ action: 'error', type: 'malware', props: {} }],
+      }),
+    ])
+
+    expect(advisories).toHaveLength(1)
+    expect(advisories[0]).toMatchObject({
+      level: 'fatal',
+      package: 'pkg:npm/lodash@4.17.21',
+      url: 'https://socket.dev/npm/package/lodash/overview/4.17.21',
+    })
+  })
+
+  test('maps a warn alert to a warn advisory', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        alerts: [{ action: 'warn', type: 'deprecation', props: {} }],
+      }),
+    ])
+
+    expect(advisories[0]!.level).toBe('warn')
+  })
+
+  test('builds the scoped socket.dev overview URL', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        inputPurl: 'pkg:npm/%40scope/pkg@1.2.3',
+        alerts: [{ action: 'error', type: 'malware', props: {} }],
+      }),
+    ])
+
+    expect(advisories[0]!.url).toBe(
+      'https://socket.dev/npm/package/@scope/pkg/overview/1.2.3',
+    )
+  })
+
+  test('prepends the typo-squat hint for a didYouMean alert', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        alerts: [
+          {
+            action: 'warn',
+            type: 'didYouMean',
+            props: { alternatePackage: 'lodash' },
+          },
+        ],
+      }),
+    ])
+
+    expect(advisories[0]!.description).toBe(
+      '\n\nThis package could be a typo-squatting attempt of another package (lodash).\n',
+    )
+  })
+
+  test('omits the typo-squat hint when alternatePackage is absent', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        alerts: [{ action: 'warn', type: 'didYouMean', props: {} }],
+      }),
+    ])
+
+    // No alternatePackage → no hint → the description is just the trailing
+    // newline joined from the seed empty string.
+    expect(advisories[0]!.description).toBe('\n')
+  })
+
+  test('assembles description, note, and fix joined by blank lines', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        alerts: [
+          {
+            action: 'error',
+            type: 'malware',
+            props: { description: 'Malicious code', note: 'Seen in the wild' },
+            fix: { description: 'Remove it' },
+          },
+        ],
+      }),
+    ])
+
+    expect(advisories[0]!.description).toBe(
+      '\n\nMalicious code\n\nSeen in the wild\n\nFix: Remove it\n',
+    )
+  })
+
+  test('skips an artifact whose purl cannot be parsed, dropping all its alerts', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        inputPurl: 'not-a-purl',
+        alerts: [
+          { action: 'error', type: 'malware', props: {} },
+          { action: 'warn', type: 'deprecation', props: {} },
+        ],
+      }),
+    ])
+
+    expect(advisories).toEqual([])
+  })
+
+  test('emits one advisory per alert on an artifact', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        alerts: [
+          { action: 'error', type: 'malware', props: {} },
+          { action: 'warn', type: 'deprecation', props: {} },
+        ],
+      }),
+    ])
+
+    expect(advisories.map(a => a.level)).toEqual(['fatal', 'warn'])
+  })
+
+  test('flattens alerts across multiple artifacts, skipping empty ones', () => {
+    const advisories = artifactsToAdvisories([
+      artifact({
+        inputPurl: 'pkg:npm/a@1.0.0',
+        alerts: [{ action: 'error', type: 'malware', props: {} }],
+      }),
+      artifact({ inputPurl: 'pkg:npm/b@2.0.0', alerts: [] }),
+      artifact({
+        inputPurl: 'pkg:npm/c@3.0.0',
+        alerts: [{ action: 'warn', type: 'deprecation', props: {} }],
+      }),
+    ])
+
+    expect(advisories.map(a => a.package)).toEqual([
+      'pkg:npm/a@1.0.0',
+      'pkg:npm/c@3.0.0',
+    ])
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,264 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from 'bun:test'
+import type { Mock } from 'bun:test'
+import type Bun from 'bun'
+import { errorMessage } from '@socketsecurity/lib-stable/errors/message'
+import { safeDelete } from '@socketsecurity/lib-stable/fs/safe'
+import { SocketSdk } from '@socketsecurity/sdk'
+import type { SocketArtifact } from '../src/types'
+
+// Every alias the token bootstrap consults, cleared before each test so a
+// stray local export can't flip the module into authenticated mode.
+// socket-api-token-env: bootstrap -- this array clears the alias-normalization chain.
+const SOCKET_API_TOKEN_ALIASES = [
+  'SOCKET_API_TOKEN',
+  'SOCKET_API_KEY',
+  'SOCKET_CLI_API_TOKEN',
+  'SOCKET_CLI_API_KEY',
+  'SOCKET_SECURITY_API_TOKEN',
+  'SOCKET_SECURITY_API_KEY',
+] as const
+
+// The bootstrap also falls back to `<dataHome>/socket/settings`; `dataHome`
+// comes from XDG_DATA_HOME (posix) or LOCALAPPDATA (win32). Point both at an
+// empty temp dir so the settings-file fallback finds nothing and the module
+// deterministically enters free mode — no real developer token can leak in.
+const EMPTY_DATA_HOME = mkdtempSync(
+  path.join(os.tmpdir(), 'bun-scanner-empty-'),
+)
+const ENV_KEYS = [
+  ...SOCKET_API_TOKEN_ALIASES,
+  'XDG_DATA_HOME',
+  'LOCALAPPDATA',
+] as const
+const ORIGINAL_ENV = new Map<string, string | undefined>(
+  ENV_KEYS.map(key => [key, process.env[key]]),
+)
+
+function arrangeFreeModeEnv(): void {
+  for (const alias of SOCKET_API_TOKEN_ALIASES) {
+    delete process.env[alias]
+  }
+  process.env['XDG_DATA_HOME'] = EMPTY_DATA_HOME
+  process.env['LOCALAPPDATA'] = EMPTY_DATA_HOME
+}
+
+function restoreEnv(): void {
+  for (const [key, value] of ORIGINAL_ENV) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+// The module resolves its token at init, so each test needs a fresh import
+// after arranging the env (query-busting defeats the module cache — the same
+// pattern dist.test.ts and live.test.ts use).
+let importCounter = 0
+type ScannerModule = {
+  scanner: Bun.Security.Scanner
+  parseNpmPurl: (purl: string) => { name: string; version: string } | undefined
+}
+async function freshScannerModule(): Promise<ScannerModule> {
+  return await import(`../src/index?index-test=${importCounter++}`)
+}
+
+describe('index (Bun.Security.Scanner conformance)', () => {
+  beforeEach(() => {
+    arrangeFreeModeEnv()
+  })
+
+  afterEach(() => {
+    restoreEnv()
+  })
+
+  afterAll(async () => {
+    await safeDelete(EMPTY_DATA_HOME)
+  })
+
+  test('empty-data-home fixture forces the settings-file miss', () => {
+    // Guards the free-mode arrangement itself: if a settings file ever existed
+    // here the e2e test below would silently hit the authenticated path.
+    expect(existsSync(path.join(EMPTY_DATA_HOME, 'socket', 'settings'))).toBe(
+      false,
+    )
+  })
+
+  test('exports a scanner with version "1" and an async scan()', async () => {
+    const { scanner } = await freshScannerModule()
+
+    expect(scanner.version).toBe('1')
+    expect(typeof scanner.scan).toBe('function')
+  })
+
+  test('re-exports parseNpmPurl', async () => {
+    const { parseNpmPurl } = await freshScannerModule()
+
+    expect(parseNpmPurl('pkg:npm/lodash@4.17.21')).toEqual({
+      name: 'lodash',
+      version: '4.17.21',
+    })
+  })
+
+  describe('scan() end-to-end in free mode', () => {
+    let fetchSpy: Mock<typeof fetch>
+
+    beforeEach(() => {
+      const mockFetch: typeof fetch = Object.assign(
+        () => Promise.resolve(new Response('')),
+        { preconnect: () => undefined },
+      )
+      fetchSpy = spyOn(global, 'fetch').mockImplementation(mockFetch)
+    })
+
+    afterEach(() => {
+      fetchSpy.mockRestore()
+    })
+
+    test('maps a firewall artifact into a fatal advisory', async () => {
+      const artifact: SocketArtifact = {
+        inputPurl: 'pkg:npm/lodahs@0.0.1-security',
+        alerts: [
+          {
+            action: 'error',
+            type: 'malware',
+            props: { description: 'Known malicious package' },
+          },
+        ],
+      }
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(artifact)))
+
+      const { scanner } = await freshScannerModule()
+      const advisories = await scanner.scan({
+        packages: [
+          {
+            name: 'lodahs',
+            version: '0.0.1-security',
+            requestedRange: '^0.0.0',
+            tarball:
+              'https://registry.npmjs.org/lodahs/-/lodahs-0.0.1-security.tgz',
+          },
+        ],
+      })
+
+      expect(advisories).toHaveLength(1)
+      expect(advisories[0]).toMatchObject({
+        level: 'fatal',
+        package: 'pkg:npm/lodahs@0.0.1-security',
+        url: 'https://socket.dev/npm/package/lodahs/overview/0.0.1-security',
+      })
+      expect(advisories[0]!.description).toContain('Known malicious package')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('returns no advisories when the firewall reports no alerts', async () => {
+      const { scanner } = await freshScannerModule()
+      const advisories = await scanner.scan({
+        packages: [
+          {
+            name: 'lodash',
+            version: '4.17.21',
+            requestedRange: '^4.0.0',
+            tarball: 'https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz',
+          },
+        ],
+      })
+
+      expect(advisories).toEqual([])
+    })
+  })
+})
+
+describe('index settings-file token fallback', () => {
+  // A data-home whose `socket/settings` file DOES exist, exercising the
+  // base64-decode token fallback the env-alias path skips.
+  let dataHome: string
+
+  function writeSettings(contents: string): void {
+    const settingsDir = path.join(dataHome, 'socket')
+    mkdirSync(settingsDir, { recursive: true })
+    writeFileSync(path.join(settingsDir, 'settings'), contents)
+  }
+
+  beforeEach(() => {
+    dataHome = mkdtempSync(path.join(os.tmpdir(), 'bun-scanner-settings-'))
+    for (const alias of SOCKET_API_TOKEN_ALIASES) {
+      delete process.env[alias]
+    }
+    process.env['XDG_DATA_HOME'] = dataHome
+    process.env['LOCALAPPDATA'] = dataHome
+  })
+
+  afterEach(async () => {
+    restoreEnv()
+    await safeDelete(dataHome)
+  })
+
+  test('reads the base64 apiToken and enters authenticated mode', async () => {
+    writeSettings(
+      Buffer.from(JSON.stringify({ apiToken: 'settings-token' })).toString(
+        'base64',
+      ),
+    )
+
+    // Prove the authenticated (SDK) path is taken rather than free-mode fetch.
+    const streamSpy = spyOn(
+      SocketSdk.prototype,
+      'batchPackageStream',
+    ).mockImplementation(
+      // Empty stream — this test only proves the SDK path runs, not what it
+      // yields. An empty async generator is assignable to the method type, so
+      // no cast is needed.
+      async function* () {},
+    )
+    const fetchSpy = spyOn(global, 'fetch')
+
+    try {
+      const { scanner } = await freshScannerModule()
+      const advisories = await scanner.scan({
+        packages: [
+          {
+            name: 'lodash',
+            version: '4.17.21',
+            requestedRange: '^4.0.0',
+            tarball: 'https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz',
+          },
+        ],
+      })
+
+      expect(advisories).toEqual([])
+      expect(streamSpy).toHaveBeenCalledTimes(1)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      streamSpy.mockRestore()
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test('throws a clear error when the settings file is unreadable', async () => {
+    // Not valid base64-of-JSON → the JSON.parse in the fallback throws.
+    writeSettings('%%% not base64 json %%%')
+
+    let thrown: unknown
+    try {
+      await freshScannerModule()
+    } catch (e) {
+      thrown = e
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(errorMessage(thrown)).toContain('error reading Socket settings')
+  })
+})


### PR DESCRIPTION
## What this does

Finishes the bun-security-scanner modernization. Three of the four goals were already delivered by earlier commits on `main` (rolldown bundling, SDK in authenticated mode, a conforming scanner shape); this PR **verifies and documents** those against the current upstream contracts and delivers the missing piece — real offline test coverage of the core scan logic.

The one behavior change is a refactor: the `scan()` alert→advisory mapping and the purl parsing move out of `src/index.ts` (which runs a token bootstrap at import) into a side-effect-free `src/advisories.ts`, so they can be unit tested without network or a token. Runtime behavior is identical.

**Coverage: offline unit suite 16 → 44 tests.** The core mapping in `src/index.ts` went from **0% offline coverage** (only the network/token-gated `live`/`dist` suites touched it) to fully exercised.

| file | funcs | lines |
|---|---|---|
| `src/advisories.ts` (new) | 100% | 100% |
| `src/index.ts` | 100% | 74.6% |
| `src/modes/authenticated.ts` | 100% | 95.7% |
| `src/modes/unauthenticated.ts` | 100% | 100% |
| `src/scanner-factory.ts` | 100% | 100% |

(The uncovered `index.ts` lines are the win32 `LOCALAPPDATA`-missing throw and the no-`XDG_DATA_HOME` `~/Library` / `.local/share` fallback — platform branches that don't run on a CI runner with `XDG_DATA_HOME` set.)

<details>
<summary>Goal 1 — conforms to the current <code>Bun.Security.Scanner</code> API</summary>

Checked the scanner against the installed `bun-types@1.3.14` `bun/security.d.ts` and the official [oven-sh/security-scanner-template](https://github.com/oven-sh/security-scanner-template). **No API delta — the contract has not broken**, and `src/index.ts` already conforms:

- `version: '1'` (string literal, required discriminator).
- `scan(info: { packages: Package[] }): Promise<Advisory[]>`.
- `Advisory` = `{ level: 'fatal' | 'warn'; package: string; url: string | null; description: string | null }`. The scanner maps `alert.action === 'error'` → `fatal`, everything else → `warn`, which matches Bun's documented behavior (any `fatal` cancels the install with a non-zero exit; otherwise `warn` prompts in a TTY / exits in CI).
- `bunfig.toml` contract is `[install.security] scanner = "..."`, unchanged.

`tsc --noEmit` passes with the export typed as `Bun.Security.Scanner`, and a new conformance test asserts `version === '1'` and that `scan` is a function.
</details>

<details>
<summary>Goal 2 — <code>@socketsecurity/sdk</code> usage (and why free mode stays a bounded fetch)</summary>

Authenticated mode already uses the SDK (`SocketSdk.batchPackageStream`, `actions=error,warn`) — unchanged here.

For free mode I evaluated SDK 4.0.3's `checkMalware()`, which hits the same `firewall-api.socket.dev/purl` endpoint token-lessly (it strips the `Authorization` header). It is **not** a drop-in replacement:

- It runs `publicPolicy` normalization and, per its own docs, "only return[s] malware-relevant results" — it would drop the non-malware alerts the scanner surfaces (e.g. `didYouMean` typo-squatting).
- The `MalwareCheckAlert` shape it returns has **no `action` field**, so the scanner could no longer distinguish `fatal` from `warn`.

So free mode keeps its minimal, bounded `fetch` to the firewall API, which returns the raw artifact alerts (with `action`) the scanner needs. This is the "no SDK-supported unauthenticated path, keep a documented bounded fetch" outcome.
</details>

<details>
<summary>Goal 3 — rolldown bundle</summary>

Already wired (`.config/repo/rolldown.config.mts`, `scripts/repo/build.mts`): single ESM entry, every runtime dep vendored, only `bun` + node builtins external. `bun run build` produces `dist/index.js` + `dist/index.d.ts`. Verified the new `src/advisories.ts` is pulled into the bundle via the import graph (no config change needed), and `test/dist.test.ts` smoke-tests the built bundle in both modes.
</details>

<details>
<summary>Goal 4 — tests + coverage (the substance of this PR)</summary>

- **`test/advisories.test.ts`** (new): `parseNpmPurl` (unscoped, scoped, percent-encoded scope, missing version, malformed) and `artifactsToAdvisories` (fatal/warn mapping, typo-squat hint, description/note/fix assembly, exact description formatting, unparseable-purl skip, one-advisory-per-alert, multi-artifact flattening). Covers 100% of the module.
- **`test/index.test.ts`** (new): scanner conformance; a deterministic **free-mode `scan()` end-to-end** that doubles only `global fetch` (the genuine external HTTP boundary) — free mode is forced by pointing `XDG_DATA_HOME`/`LOCALAPPDATA` at an empty temp dir so no real developer token can leak in; and the **settings-file token fallback** (valid base64 `apiToken` → authenticated SDK path; unreadable file → throws `error reading Socket settings`).

No owned-infrastructure mocking: doubles are limited to `global fetch` and, for the settings-file authenticated-path assertion, a `spyOn` of the SDK method (matching the existing `authenticated.test.ts` convention).
</details>

## Verification

- `bun test` — 49 pass, 0 fail across 8 files (the `live` suite self-skips without a token; `dist` smoke-tests the built bundle).
- `bun run build` — succeeds (rolldown bundle + d.ts).
- `tsc --noEmit`, fleet `oxlint` + `oxfmt` — clean.

## Deferred / not included

- **Free-mode request timeout (SURF-1041)** is handled by the already-open **#19**, which is scoped to `src/modes/unauthenticated.ts`. This PR intentionally does not touch that file, so the two don't conflict; #19's timeout behavior is preserved.
