### PR TITLE
ci: gate setup-bun cache off tag refs (zizmor cache-poisoning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
       # same SHA the release workflow uses.
       - name: Setup Bun
         uses: oven-sh/setup-bun@22457c87c1b161cf7dde222c3e82b2b5f8d2bed2
+        with:
+          # setup-bun caches by default, and this workflow also runs on
+          # `push: tags: ['*']`. A tag/release ref restoring a cache a
+          # less-trusted branch/PR run populated is the cache-poisoning
+          # vector zizmor flags (error[cache-poisoning] on ci.yml). Gate
+          # the cache off for tag refs only — ordinary branch/PR CI keeps
+          # a warm bun cache. See https://docs.zizmor.sh/audits/#cache-poisoning
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       - uses: ./.github/actions/fleet/run-script
         env:
           # Authenticate build-time GitHub API reads (release listings,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to `@socketsecurity/bun-security-scanner` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Socket Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
-<img src="https://bun.com/logo.png" height="36" />
-
 # Socket's Bun Security Scanner
 
+<a href="https://socket.dev/npm/package/@socketsecurity/bun-security-scanner"><img src="https://socket.dev/api/badge/npm/package/@socketsecurity/bun-security-scanner" alt="Socket Badge" height="20"></a>
+<img src="assets/repo/badges/coverage.svg" width="97" height="20" alt="Coverage" />
+
+[![Follow @SocketSecurity](assets/fleet/badge-follow-x.svg)](https://twitter.com/SocketSecurity)
+[![Follow @socket.dev on Bluesky](assets/fleet/badge-follow-bluesky.svg)](https://bsky.app/profile/socket.dev)
+
 Official Socket Security scanner for Bun's package installation process. Protects your projects from malicious packages, typosquatting, and other supply chain attacks.
+
+## Why this repo exists
+
+Bun's package installer exposes a security-provider API that lets a scanner
+vet every package before it is installed. This repo is Socket's implementation
+of that provider: it checks each package against Socket's threat intelligence
+during `bun install`, blocking malware, typosquats, and other supply-chain
+attacks before they reach your machine. It runs with no configuration in free
+mode, and applies your Socket organization's policy when a token is present.
 
 ## Features
 
@@ -12,13 +25,13 @@ Official Socket Security scanner for Bun's package installation process. Protect
 - 🔐 Supports both authenticated (Socket org) and free modes
 - 🎯 Native integration with Bun's security provider API
 
-## Installation
+## Install
 
 ```bash
 bun add -d @socketsecurity/bun-security-scanner
 ```
 
-## Configuration
+## Usage
 
 Add to your `bunfig.toml`:
 
@@ -46,8 +59,26 @@ The scanner will automatically read your token from:
 
 Without a token, the scanner runs in free mode using Socket's public API.
 
-## Support
+## Development
+
+<details>
+<summary>Contributor commands</summary>
+
+```sh
+pnpm install
+pnpm run build
+pnpm run check
+pnpm run test
+```
+
+</details>
+
+### Support
 
 - [Socket Documentation](https://socket.dev/docs)
 - [Bun Security Scanner API](https://bun.com/docs/install/security-scanner-api)
 - [Report Issues](https://github.com/SocketDev/bun-security-scanner/issues)
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`🔎 Check` fails on every recent run with a zizmor high-severity finding, exit 14:

\`\`\`
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> .github/workflows/ci.yml:128:9
128 |         uses: oven-sh/setup-bun@22457c87c1b161cf7dde222c3e82b2b5f8d2bed2
    |         ^^^ enables caching by default
\`\`\`

`ci.yml` runs on `push: tags: ['*']` and the repo-local **Setup Bun** step (`oven-sh/setup-bun`) caches by default. A tag/release ref restoring a bun cache that a less-trusted branch/PR run populated is the cache-poisoning vector zizmor flags.

## Fix

Gate the setup-bun cache off for tag refs only:

\`\`\`yaml
no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
\`\`\`

Ordinary branch and PR CI keep a warm bun cache; only release-shaped refs skip it. This is zizmor's documented remediation (disable caching for tag/release events, keep it elsewhere) and is more surgical than a wholesale `no-cache: true`.

## Scope

This is a **bun-security-scanner-local** workflow step, not a fleet-source issue. The fleet-standard actions nest their caching inside composite actions (which zizmor's cache-poisoning audit does not descend into) and their publish workflows are `workflow_dispatch`-triggered, so the fleet actions themselves are clean.

## Verification

- Before: `zizmor .github --min-severity medium` (the exact `🔎 Check` invocation, zizmor 1.26.1 per `external-tools.json`) -> exit 14, 1 high.
- After: same invocation -> exit 0, no findings. 0 cache-poisoning findings even at `--min-severity low`.
- pre-commit hook passed locally (lint + full `bun test`: 47 pass, 2 skip, 0 fail).